### PR TITLE
Get Currency by Symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ You can import this package in TypeScript or JavaScript. The package is TypeScri
 **ESM / TypeScript:**
 
 ```ts
-import { getAllCurrencies, getCurrencyByCountry, getCurrencyByCode } from "@mfaeezshabbir/world-currencies";
+import { getAllCurrencies, getCurrencyByCountry, getCurrencyByCode, getCurrencyBySymbol } from "@mfaeezshabbir/world-currencies";
 
 console.log(getAllCurrencies());
 console.log(getCurrencyByCountry("Pakistan"));
 console.log(getCurrencyByCode("USD"));
+console.log(getCurrencyBySymbol("$"));
 ```
 
 **CommonJS:**
@@ -84,6 +85,7 @@ Each record in the dataset follows this structure:
 | `getAllCurrencies()`            | Returns the full list of currencies                  |
 | `getCurrencyByCountry(country)` | Finds a currency by country name (case-insensitive)  |
 | `getCurrencyByCode(code)`       | Finds a currency by ISO 4217 code (case-insensitive) |
+| `getCurrencyBySymbol(symbol)`   | Finds a currency (list of array) by it's symbol      |
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,15 @@ export function getCurrencyByCode(code?: string): Currency | null {
   );
   return found || null;
 }
+
+
+/**
+ * Finds currency data (list of array) by it's symbol.
+ */
+export function getCurrencyBySymbol(symbol?: string): Currency[] | null {
+  if (!symbol) return null;
+  const found = currencies.filter(
+    (c) => (c.symbol || "") === symbol
+  );
+  return found || null;
+}


### PR DESCRIPTION
This PR adds a new utility function `getCurrencyBySymbol` to the world-currencies dataset module.

### **Summary of Changes**

* **Added function:** `getCurrencyBySymbol(symbol?: string): Currency[] | null`

  * Returns an array of currencies matching the provided symbol.
  * Returns `null` if no symbol is provided or no match is found.
* Updated JSDoc comments to include usage details.

### **Example Usage**

```ts
getCurrencyBySymbol("$");
```

**Output:**

```js
[
  { country: "United States", currency: "United States dollar", symbol: "$", code: "USD" },
  { country: "Australia", currency: "Australian dollar", symbol: "$", code: "AUD" },
  { country: "Canada", currency: "Canadian dollar", symbol: "$", code: "CAD" },
  ...
]
```

### **Motivation**

The dataset previously supported lookups by country and ISO code only.
This addition enables developers to query currencies by symbol — useful for cases where users input or display currency symbols instead of country or code.

### **Testing**

* Verified with multiple symbols (e.g., `$`, `€`, `£`, `¥`).
* Confirmed that multiple countries sharing the same symbol return as an array.
* Confirmed null handling for missing or invalid symbols.

